### PR TITLE
Use major version for auto-release

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -24,7 +24,7 @@ jobs:
       - run: git config --global user.email "dummybitcoinjsgabot@example.com"
       - run: git config --global user.name "Github Actions"
       - run: git commit -am "Update index.js"
-      - run: npm version patch
+      - run: npm version major
       - run: mkdir -p ~/.ssh
       - run: echo "${{secrets.deploy_key}}" > ~/.ssh/id_rsa
       - run: chmod 600 ~/.ssh/id_rsa


### PR DESCRIPTION
Some breaking changes have appeared from time to time.

Since npm install default won't pick up major changes, this will force all users to basically choose their version specifically.

Considering the contents of this library that seems reasonable.