### PR TITLE
chore: fix export declaration of types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -9,6 +9,6 @@ export type Entry = [
   CoinTypeTitle,
 ];
 
-const entries: Entry[];
+export const entries: Entry[];
 
 export default entries;


### PR DESCRIPTION
When the default type-safe script is run in a generic app, it may present an error:

```shell
> tsc --emitDeclarationOnly --outDir dist/types

Error: node_modules/bip44-constants/index.d.ts(12,1): error TS1046: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier.
```

To prevent it, we modified the declaration file.
